### PR TITLE
Metadata update

### DIFF
--- a/src/AdoptAHyphen.sol
+++ b/src/AdoptAHyphen.sol
@@ -24,13 +24,13 @@ contract AdoptAHyphen is IAdoptAHyphen, ERC721, ERC721TokenReceiver, Owned {
         unicode"oice, thousands of innocent hyphens are losing their place in t"
         unicode"he world. No longer needed to hold “on-chain” together, these h"
         unicode"yphens are in need of a loving place to call home. What if you "
-        unicode"could make a difference in a hyphen’s life forever?\\n\\nIntroduc"
-        unicode"ing the Adopt-a-Hyphen program, where you can adopt a hyphen an"
-        unicode"d give it a new home...right in your wallet! Each hyphen in thi"
-        unicode"s collection was adopted via an on-chain mint and is now safe a"
-        unicode"nd sound in this collection. As is their nature, each hyphen li"
-        unicode"ves fully on-chain and is rendered in Solidity as cute, generat"
-        unicode"ive ASCII art.";
+        unicode"could make a difference in a hyphen’s life forever?\\n\\nIntrod"
+        unicode"ucing the Adopt-a-Hyphen program, where you can adopt a hyphen "
+        unicode"and give it a new home...right in your wallet! Each hyphen in t"
+        unicode"his collection was adopted via an on-chain mint and is now safe"
+        unicode" and sound in this collection. As is their nature, each hyphen "
+        unicode"lives fully on-chain and is rendered in Solidity as cute, gener"
+        unicode"taive ASCII art.";
 
     // -------------------------------------------------------------------------
     // Immutable storage

--- a/src/AdoptAHyphen.sol
+++ b/src/AdoptAHyphen.sol
@@ -13,6 +13,29 @@ import {AdoptAHyphenMetadata} from "./utils/AdoptAHyphenMetadata.sol";
 /// @notice Adopt a Hyphen: exchange a Hyphen NFT into this contract to mint a
 /// Hyphen Guy.
 contract AdoptAHyphen is IAdoptAHyphen, ERC721, ERC721TokenReceiver, Owned {
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    /// @notice Description of the collection.
+    string constant COLLECTION_DESCRIPTION =
+        unicode"With each passing day, more and more people are switching from "
+        unicode"“on-chain” to “onchain.” While this may seem like a harmless ch"
+        unicode"oice, thousands of innocent hyphens are losing their place in t"
+        unicode"he world. No longer needed to hold “on-chain” together, these h"
+        unicode"yphens are in need of a loving place to call home. What if you "
+        unicode"could make a difference in a hyphen’s life forever?\\n\\nIntroduc"
+        unicode"ing the Adopt-a-Hyphen program, where you can adopt a hyphen an"
+        unicode"d give it a new home...right in your wallet! Each hyphen in thi"
+        unicode"s collection was adopted via an on-chain mint and is now safe a"
+        unicode"nd sound in this collection. As is their nature, each hyphen li"
+        unicode"ves fully on-chain and is rendered in Solidity as cute, generat"
+        unicode"ive ASCII art.";
+
+    // -------------------------------------------------------------------------
+    // Immutable storage
+    // -------------------------------------------------------------------------
+
     /// @notice The Hyphen NFT contract that must be transferred into this
     /// contract in order to mint a token.
     IERC721 public immutable override hyphenNft;
@@ -69,6 +92,8 @@ contract AdoptAHyphen is IAdoptAHyphen, ERC721, ERC721TokenReceiver, Owned {
                     abi.encodePacked(
                         '{"name":"',
                         name,
+                        '","description":"',
+                        COLLECTION_DESCRIPTION,
                         '","image_data":"data:image/svg+xml;base64,',
                         Base64.encode(
                             abi.encodePacked(AdoptAHyphenArt.render(seed))
@@ -76,6 +101,25 @@ contract AdoptAHyphen is IAdoptAHyphen, ERC721, ERC721TokenReceiver, Owned {
                         '","attributes":',
                         attributes,
                         "}"
+                    )
+                )
+            );
+    }
+
+    // -------------------------------------------------------------------------
+    // Contract metadata
+    // -------------------------------------------------------------------------
+
+    /// @inheritdoc IAdoptAHyphen
+    function contractURI() external pure override returns (string memory) {
+        return
+            string.concat(
+                "data:application/json;base64,",
+                Base64.encode(
+                    abi.encodePacked(
+                        '{"name":"Adopt-a-Hyphen","description":"',
+                        COLLECTION_DESCRIPTION,
+                        '"}'
                     )
                 )
             );

--- a/src/AdoptAHyphen.sol
+++ b/src/AdoptAHyphen.sol
@@ -5,9 +5,9 @@ import {ERC721, ERC721TokenReceiver} from "solmate/tokens/ERC721.sol";
 import {Owned} from "solmate/auth/Owned.sol";
 import {IAdoptAHyphen} from "./interfaces/IAdoptAHyphen.sol";
 import {IERC721} from "./interfaces/IERC721.sol";
-import {Base64} from "./utils/Base64.sol";
 import {AdoptAHyphenArt} from "./utils/AdoptAHyphenArt.sol";
 import {AdoptAHyphenMetadata} from "./utils/AdoptAHyphenMetadata.sol";
+import {Base64} from "./utils/Base64.sol";
 
 /// @title adopt-a-hyphen
 /// @notice Adopt a Hyphen: exchange a Hyphen NFT into this contract to mint a

--- a/src/AdoptAHyphen.sol
+++ b/src/AdoptAHyphen.sol
@@ -25,7 +25,7 @@ contract AdoptAHyphen is IAdoptAHyphen, ERC721, ERC721TokenReceiver, Owned {
     constructor(
         address _hyphenNft,
         address _owner
-    ) ERC721("adopt-a-hyphen", "-") Owned(_owner) {
+    ) ERC721("Adopt-a-Hyphen", "-") Owned(_owner) {
         hyphenNft = IERC721(_hyphenNft);
     }
 

--- a/src/AdoptAHyphen.sol
+++ b/src/AdoptAHyphen.sol
@@ -30,7 +30,7 @@ contract AdoptAHyphen is IAdoptAHyphen, ERC721, ERC721TokenReceiver, Owned {
         unicode"his collection was adopted via an on-chain mint and is now safe"
         unicode" and sound in this collection. As is their nature, each hyphen "
         unicode"lives fully on-chain and is rendered in Solidity as cute, gener"
-        unicode"taive ASCII art.";
+        unicode"ative ASCII art.";
 
     // -------------------------------------------------------------------------
     // Immutable storage

--- a/src/interfaces/IAdoptAHyphen.sol
+++ b/src/interfaces/IAdoptAHyphen.sol
@@ -32,4 +32,11 @@ interface IAdoptAHyphen {
     /// @dev `msg.sender` must have approvals set to `true` on the hyphen NFT
     /// with the operator as this contract's address.
     function mint(uint256 _tokenId) external;
+
+    // -------------------------------------------------------------------------
+    // Metadata
+    // -------------------------------------------------------------------------
+
+    /// @return The contract URI for this contract.
+    function contractURI() external view returns (string memory);
 }

--- a/src/utils/AdoptAHyphenArt.sol
+++ b/src/utils/AdoptAHyphenArt.sol
@@ -490,8 +490,7 @@ library AdoptAHyphenArt {
                 // (`3 * 51 = 153`), and we have the same 20px overhead as
                 // before, so `153 + 20 = 173`. `width` is `536` for the same
                 // reason. Finally, `height` is `204` because the character is 4
-                // lines tall, and each line is 51 pixels tall:
-                // `4 * 51 = 204`.
+                // lines tall, and each line is 51 pixels tall: `4 * 51 = 204`.
                 'N</pre></foreignObject><foreignObject x="32" y="173" width="53'
                 '6" height="204"><pre',
                 hyphenGuy.inverted

--- a/src/utils/AdoptAHyphenMetadata.sol
+++ b/src/utils/AdoptAHyphenMetadata.sol
@@ -21,25 +21,25 @@ library AdoptAHyphenMetadata {
     /// @dev To read from this constant, use
     /// `LibString.split(string(ADJECTIVES), "_")`.
     bytes constant ADJECTIVES =
-        "all-important_angel-faced_awe-inspiring_battle-scarred_big-boned_bird-"
-        "like_black-and-white_breath-taking_bright-eyed_broad-shouldered_bull-h"
-        "eaded_butter-soft_cat-eyed_cool-headed_cross-eyed_death-defying_devil-"
-        "may-care_dew-fresh_dim-witted_down-to-earth_eagle-nosed_easy-going_eve"
-        "r-changing_faint-hearted_feather-brained_fish-eyed_fly-by-night_free-t"
-        "hinking_fun-loving_half-baked_hawk-eyed_heart-breaking_high-spirited_h"
-        "oney-dipped_honey-tongued_ice-cold_ill-gotten_iron-grey_iron-willed_ke"
-        "en-eyed_kind-hearted_left-handed_lion-hearted_off-the-grid_open-faced_"
-        "pale-faced_razor-sharp_red-faced_rosy-cheeked_ruby-red_self-satisfied_"
-        "sharp-nosed_short-sighted_silky-haired_silver-tongued_sky-blue_slow-fo"
-        "oted_smooth-as-silk_smooth-talking_snake-like_snow-cold_snow-white_sof"
-        "t-voiced_sour-faced_steel-blue_stiff-necked_straight-laced_strong-mind"
-        "ed_sugar-sweet_thick-headed_tight-fisted_tongue-in-cheek_tough-minded_"
-        "trigger-happy_velvet-voiced_water-washed_white-faced_wide-ranging_wild"
-        "-haired_wishy-washy_work-weary_yellow-bellied_camera-shy_cold-as-ice_e"
-        "mpty-handed_fair-weather_fire-breathing_jaw-dropping_mind-boggling_no-"
-        "nonsense_rough-and-ready_slap-happy_smooth-faced_snail-paced_soul-sear"
-        "ching_star-studded_tongue-tied_too-good-to-be-true_turtle-necked_diamo"
-        "nd-handed";
+        "All-Important_Angel-Faced_Awe-Inspiring_Battle-Scarred_Big-Boned_Bird-"
+        "Like_Black-and-White_Breath-Taking_Bright-Eyed_Broad-Shouldered_Bull-H"
+        "eaded_Butter-Soft_Cat-Eyed_Cool-Headed_Cross-Eyed_Death-Defying_Devil-"
+        "May-Care_Dew-Fresh_Dim-Witted_Down-to-Earth_Eagle-Nosed_Easy-Going_Eve"
+        "r-Changing_Faint-Hearted_Feather-Brained_Fish-Eyed_Fly-by-Night_Free-T"
+        "hinking_Fun-Loving_Half-Baked_Hawk-Eyed_Heart-Breaking_High-Spirited_H"
+        "oney-Dipped_Honey-Tongued_Ice-Cold_Ill-Gotten_Iron-Grey_Iron-Willed_Ke"
+        "en-Eyed_Kind-Hearted_Left-Handed_Lion-Hearted_Off-the-Grid_Open-Faced_"
+        "Pale-Faced_Razor-Sharp_Red-Faced_Rosy-Cheeked_Ruby-Red_Self-Satisfied_"
+        "Sharp-Nosed_Short-Sighted_Silky-Haired_Silver-Tongued_Sky-Blue_Slow-Fo"
+        "oted_Smooth-as-Silk_Smooth-Talking_Snake-Like_Snow-Cold_Snow-White_Sof"
+        "t-Voiced_Sour-Faced_Steel-Blue_Stiff-Necked_Straight-Laced_Strong-Mind"
+        "ed_Sugar-Sweet_Thick-Headed_Tight-Fisted_Tongue-in-Cheek_Tough-Minded_"
+        "Trigger-Happy_Velvet-Voiced_Water-Washed_White-Faced_Wide-Ranging_Wild"
+        "-Haired_Wishy-Washy_Work-Weary_Yellow-Bellied_Camera-Shy_Cold-as-Ice_E"
+        "mpty-Handed_Fair-Weather_Fire-Breathing_Jaw-Dropping_Mind-Boggling_No-"
+        "Nonsense_Rough-and-ready_Slap-Happy_Smooth-Faced_Snail-Paced_Soul-Sear"
+        "ching_Star-Studded_Tongue-Tied_Too-Good-to-be-True_Turtle-Necked_Diamo"
+        "nd-Handed";
 
     /// @notice Joined list of first names to use when generating the name with
     /// `_` as the delimiter.

--- a/src/utils/AdoptAHyphenMetadata.sol
+++ b/src/utils/AdoptAHyphenMetadata.sol
@@ -46,9 +46,11 @@ library AdoptAHyphenMetadata {
     /// @dev To read from this constant, use
     /// `LibString.split(string(FIRST_NAMES), "_")`.
     bytes constant FIRST_NAMES =
-        "james_robert_john_mike_david_will_richard_joe_tom_chris_charles_dan_ma"
-        "tt_tony_mark_mary_patty_jenny_linda_liz_barb_sue_jess_sarah_karen_lisa"
-        "_nancy_betty_sandra_peggy";
+        "Alexis_Ali_Alicia_Andres_Asha_Barb_Betty_Bruce_Charles_Chris_Coco_Dan_"
+        "David_Dennis_Elijah_Eugene_James_Jayden_Jenny_Jess_Joe_John_Jose_Karen"
+        "_Linda_Lisa_Liz_Marco_Mark_Mary_Matt_Mert_Mike_Mirra_Nancy_Noor_Novak_"
+        "Patty_Peggy_Ravi_Richard_Robert_Sandra_Sarah_Sue_Tayne_Tom_Tony_Will_Y"
+        "ana";
 
     /// @notice Joined list of hue names to use when generating the name with
     /// `_` as the delimiter.
@@ -78,7 +80,7 @@ library AdoptAHyphenMetadata {
             string.concat(
                 adjectives[_seed % 100],
                 " ",
-                firstNames[(_seed >> 7) % 30] // Adjectives used 7 bits
+                firstNames[(_seed >> 7) % 50] // Adjectives used 7 bits
             );
     }
 


### PR DESCRIPTION
- Refactors collection `name()`: `adopt-a-hyphen` $\rightarrow$ `Adopt-a-Hyphen`.
- Capitalizes adjective and names.
- Adds 20 names.
- Adds contact-level metadata queryable with `contractURI()`.